### PR TITLE
~ Support \sim symbol

### DIFF
--- a/src/macros.ts
+++ b/src/macros.ts
@@ -75,4 +75,5 @@ export const typstMacros: Record<string, string | ((node: LatexNode) => string)>
   },
   vdots: 'dots.v',
   ddots: 'dots.down',
+  sim: 'tilde',
 };

--- a/tests/math.yml
+++ b/tests/math.yml
@@ -101,3 +101,6 @@ cases:
   - title: leading power
     tex: '^{\text{st}}'
     typst: '""^("st")'
+  - title: sim symbol
+    tex: 'a \sim b'
+    typst: a tilde b


### PR DESCRIPTION
There are many more latex symbols which should be supported here... https://oeis.org/wiki/List_of_LaTeX_mathematical_symbols => https://typst.app/docs/reference/symbols/sym/