### PR TITLE
🔧 A few more conversions

### DIFF
--- a/src/macros.ts
+++ b/src/macros.ts
@@ -76,6 +76,7 @@ export const typstMacros: Record<string, string | ((state: IState, node: LatexNo
   check: 'caron',
   bar: 'macron',
   mathbf: 'bold',
+  mathsf: 'sans',
   boldsymbol: 'bold',
   bf: 'bold',
   mathrm: 'upright',

--- a/tests/math.yml
+++ b/tests/math.yml
@@ -97,8 +97,8 @@ cases:
       }_{\mathbf{B}(\psi^{n+1})}&
       \end{align*}
     typst: |-
-      overbrace([ frac(1, Delta t) frac(diff bold(theta)^(n + 1), diff bold(psi)^(n + 1)) -bold(D) "diag"(bold(G) bold(psi)^(n + 1)) frac(diff bold(k)_(A v), diff bold(psi)^(n + 1)) -bold(D) "diag"(bold(k)_(A v) (bold(psi)^(n + 1) comma bold(m))) bold(G) -bold(G)_z frac(diff bold(k)_(A v), diff bold(psi)^(n + 1)) ], bold(A)_0 (bold(psi)^(n + 1))) frac(diff bold(psi)^(n + 1), diff bold(m)) \
-      + underbrace([ -frac(1, Delta t) frac(diff bold(theta)^n, diff bold(psi)^n) ], bold(A)_(-1) (bold(psi)^n)) frac(diff bold(psi)^n, diff bold(m)) = underbrace([ -bold(D) "diag"(bold(G) bold(psi)^(n + 1)) frac(diff bold(k)_(A v), diff bold(m)) -bold(G)_z frac(diff bold(k)_(A v), diff bold(m)) ], bold(B) (psi^(n + 1))) &
+      overbrace([ frac(1, Delta t) frac(diff bold(theta)^(n + 1), diff bold(psi)^(n + 1)) -bold(D) " diag"(bold(G) bold(psi)^(n + 1)) frac(diff bold(k)_(A v), diff bold(psi)^(n + 1)) -bold(D) " diag"(bold(k)_(A v) (bold(psi)^(n + 1) comma bold(m))) bold(G) -bold(G)_z frac(diff bold(k)_(A v), diff bold(psi)^(n + 1)) ], bold(A)_0 (bold(psi)^(n + 1))) frac(diff bold(psi)^(n + 1), diff bold(m)) \
+      + underbrace([ -frac(1, Delta t) frac(diff bold(theta)^n, diff bold(psi)^n) ], bold(A)_(-1) (bold(psi)^n)) frac(diff bold(psi)^n, diff bold(m)) = underbrace([ -bold(D) " diag"(bold(G) bold(psi)^(n + 1)) frac(diff bold(k)_(A v), diff bold(m)) -bold(G)_z frac(diff bold(k)_(A v), diff bold(m)) ], bold(B) (psi^(n + 1))) &
   - title: underbraces inside of a function
     description: For some reason the "_" here is treated as text, not a macro.
     tex: |
@@ -266,7 +266,7 @@ cases:
     typst: '\$ 50, 000'
   - title: quotes
     tex: 'V = \{ \text{"ng", "mr", "sr"} \}'
-    typst: 'V = {"\"ng\",\"mr\",\"sr\""}'
+    typst: 'V = {"\"ng\", \"mr\", \"sr\""}'
   - title: color
     tex: '\color{red}{V}'
     typst: '#text(fill: red)[$V$]'
@@ -390,3 +390,9 @@ cases:
   - title: horizontal space
     tex: '\hspace{1cm}'
     typst: '#h(1cm)'
+  - title: text with spaces
+    tex: '\text{ Hello  !!}'
+    typst: '" Hello  !!"'
+  - title: mathsf
+    tex: '\mathsf{k}'
+    typst: 'sans(k)'


### PR DESCRIPTION
I was looking to try to implement some of the features from this plugin: https://github.com/jupyter-book/myst-plugins/blob/main/plugins/typst-conversion-support/typst_conversion-support.mjs

There are still a couple I wasn't sure about usage or expected conversion - `hline`, `substack`