### PR TITLE
Add alternative variable names for mathematical symbols

### DIFF
--- a/src/macros.ts
+++ b/src/macros.ts
@@ -68,13 +68,6 @@ export const typstMacros: Record<string, string | ((state: IState, node: LatexNo
   oint: 'integral.cont',
   oiint: 'integral.surf',
   oiiint: 'integral.vol',
-  varepsilon:	'epsilon', 
-  vartheta:	'theta.alt',
-  varpi:	'pi.alt',
-  varrho:	'rho.alt',
-  varsigma:	'sigma.alt',
-  varphi:	'phi',
-  
   sqrt: (state, node) => {
     if (isEmptyNode(node.args?.[0])) return 'sqrt';
     return 'root';
@@ -180,6 +173,9 @@ export const typstMacros: Record<string, string | ((state: IState, node: LatexNo
   phi: 'phi.alt',
   varphi: 'phi.alt',
   varepsilon: 'epsilon',
+  vartheta:	'theta.alt',
+  varrho:	'rho.alt',
+  varsigma:	'sigma.alt',
   propto: 'prop',
   mapsto: 'mapsto',
   equiv: 'equiv',


### PR DESCRIPTION
Included \vartheta and others which seemed not yet supported