### PR TITLE
{ Support cases

### DIFF
--- a/.changeset/forty-suns-pull.md
+++ b/.changeset/forty-suns-pull.md
@@ -1,0 +1,5 @@
+---
+'tex-to-typst': patch
+---
+
+Support quoted math text

--- a/.changeset/little-foxes-hunt.md
+++ b/.changeset/little-foxes-hunt.md
@@ -1,0 +1,5 @@
+---
+'tex-to-typst': patch
+---
+
+Support cases

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,9 +404,10 @@ function convert(state: IState, node: LatexNode) {
 }
 
 function convertText(state: IState, text: string): string {
+  if (!(text in typstStrings)) return text;
   const result = typstStrings[text];
-  if (typeof result === 'function') return result(state) || text;
-  return result || text;
+  if (typeof result === 'function') return result(state);
+  return result;
 }
 
 export function writeTypst(node: LatexNode, state: IState = new State()) {

--- a/src/macros.ts
+++ b/src/macros.ts
@@ -77,6 +77,17 @@ for (const [typst, sym] of Object.entries(symbols)) {
   }
 }
 
+function quotedMathText(state: IState, node: LatexNode, wrapper: string) {
+  const arg = node.args?.[0] as LatexNode;
+  node.args = [];
+  state.write(`${wrapper}(`);
+  state.openFunction('text');
+  state.writeChildren(arg);
+  state.closeFunction();
+  state.write(')');
+  return '';
+}
+
 const baseMacros: Record<string, string | ((state: IState, node: LatexNode) => string)> = {
   $: '\\$',
   dfrac: 'frac',
@@ -99,6 +110,10 @@ const baseMacros: Record<string, string | ((state: IState, node: LatexNode) => s
   mathrm: 'upright',
   textrm: 'upright',
   rm: 'upright',
+  textit: (state, node) => quotedMathText(state, node, 'italic'),
+  emph: (state, node) => quotedMathText(state, node, 'italic'),
+  textbf: (state, node) => quotedMathText(state, node, 'bold'),
+  texttt: (state, node) => quotedMathText(state, node, 'mono'),
   mbox: (state, node) => {
     const arg = node.args?.[0] as LatexNode;
     node.args = [];

--- a/src/macros.ts
+++ b/src/macros.ts
@@ -8,10 +8,14 @@ function isEmptyNode(node?: LatexNode): boolean {
 }
 
 export const typstStrings: Record<string, string | ((state: IState) => string)> = {
-  ',': (state) =>
-    state.data.inFunction && (state as any)._currentFunctions.slice(-1)[0] !== 'text'
+  ',': (state) => {
+    // LaTeX cases rows are often written as `i, & condition`; the comma is
+    // typographic and `&` already maps to the Typst cases argument separator.
+    if (state.data.inCases) return '';
+    return state.data.inFunction && (state as any)._currentFunctions.slice(-1)[0] !== 'text'
       ? 'comma'
-      : ',',
+      : ',';
+  },
   '&': (state) => (state.data.inArray ? ',' : '&'),
   '/': '\\/',
   ';': '\\;',
@@ -191,6 +195,9 @@ const baseMacros: Record<string, string | ((state: IState, node: LatexNode) => s
   mathop: 'op',
   '\\': (state, node) => {
     node.args = [];
+    if (state.data.inCases) {
+      return ',';
+    }
     if (state.data.inArray) {
       state.data.previousMatRows = (state.data.previousMatRows ?? 0) + 1;
       if ((state as any)._value.slice(-1) === ']') state.addWhitespace();
@@ -200,6 +207,9 @@ const baseMacros: Record<string, string | ((state: IState, node: LatexNode) => s
   },
   cr: (state, node) => {
     node.args = [];
+    if (state.data.inCases) {
+      return ',';
+    }
     if (state.data.inArray) {
       state.data.previousMatRows = (state.data.previousMatRows ?? 0) + 1;
       if ((state as any)._value.slice(-1) === ']') state.addWhitespace();
@@ -363,6 +373,16 @@ const matrixEnv = (delim?: string) => (state: IState, node: LatexNode) => {
   state.data.inArray = false;
 };
 
+const casesEnv = (state: IState, node: LatexNode) => {
+  state.data.inArray = true;
+  state.data.inCases = true;
+  state.openFunction('cases');
+  state.writeChildren(node);
+  state.closeFunction();
+  state.data.inArray = false;
+  state.data.inCases = false;
+};
+
 export const typstEnvs: Record<string, (state: IState, node: LatexNode) => void> = {
   array: matrixEnv(),
   matrix: matrixEnv(),
@@ -370,6 +390,7 @@ export const typstEnvs: Record<string, (state: IState, node: LatexNode) => void>
   bmatrix: matrixEnv('['),
   Bmatrix: matrixEnv('{'),
   vmatrix: matrixEnv('|'),
+  cases: casesEnv,
   aligned(state, node) {
     state.writeChildren(node);
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type StateData = {
   writeOutBrackets?: boolean;
   inFunction?: boolean;
   inArray?: boolean;
+  inCases?: boolean;
   previousMatRows?: number;
   macros?: Set<string>;
 };

--- a/tests/math.yml
+++ b/tests/math.yml
@@ -185,6 +185,9 @@ cases:
   - title: text subscript in function
     tex: '\text{SR} = \sum{t_{active}}'
     typst: '"SR" = sum t_(a c t i v e)'
+  - title: textit
+    tex: '\textit{Enrichment score} = \frac{\textit{Count}}{\textit{Pool}}'
+    typst: 'italic("Enrichment score") = frac(italic("Count"), italic("Pool"))'
   - title: tilde
     tex: '\tilde{I}'
     typst: 'tilde(I)'

--- a/tests/math.yml
+++ b/tests/math.yml
@@ -393,6 +393,9 @@ cases:
   - title: left right angle
     tex: '\left\langle A \right\rangle'
     typst: 'chevron.l A chevron.r'
+  - title: triangleq
+    tex: 'F_A(k) \triangleq \mathcal{F}[\tilde{A}](k)'
+    typst: 'F_A (k) eq.delta cal(F) [ tilde(A) ] (k)'
   - title: horizontal space
     tex: '\hspace{1cm}'
     typst: '#h(1cm)'

--- a/tests/math.yml
+++ b/tests/math.yml
@@ -465,3 +465,9 @@ cases:
   - title: mismatched bracket delimiters around matrix use lr
     tex: '\left[ \begin{matrix} a & b \end{matrix} \right)'
     typst: 'lr([mat(delim: #none, a, b)))'
+  - title: cases environment
+    tex: 'A_0(x) = \begin{cases} A(x), & A(x) \geq c \\ 0, & \text{otherwise} \end{cases}'
+    typst: 'A_0 (x) = cases(A (x), A (x) gt.eq c, 0, "otherwise")'
+  - title: cases environment with floor
+    tex: '\text{wrap}(i; n) = \begin{cases} i, & i \leq \lfloor n/2 \rfloor \\ i - n, & \text{otherwise.} \end{cases}'
+    typst: '"wrap"(i \; n) = cases(i, i lt.eq floor.l n \/ 2 floor.r, i -n, "otherwise.")'


### PR DESCRIPTION
Adds support for `\cases` macro. Also supports macros for text in math like `textit`.